### PR TITLE
Specify bitHound lint engine and long files rule

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -50,5 +50,9 @@
     "**/tests/**",
     "**/spec/**",
     "**/specs/**"
-  ]
+  ],
+  "critics": {
+    "lint": {"engine": "eslint"},
+    "wc": { "limit": 3000 }
+  }
 }


### PR DESCRIPTION
Relax long files rule and explicitly specify to use eslint